### PR TITLE
Upgrade CLOUD_HYPERVISOR to tag gardenlinux-release-26-05-19 (eabdd84f6582b9e08f7865b13b24f8ea76ec646e)

### DIFF
--- a/prepare_source
+++ b/prepare_source
@@ -1,8 +1,8 @@
 # vim: ft=bash
 
 # commit sha from https://github.com/cyberus-technology/cloud-hypervisor/commits/gardenlinux/
-CLOUD_HYPERVISOR_COMMIT_SHA="c5d32dd5f2d897fac6b7e0c5640c181e8a71e5aa"
-version_increment="8"
+CLOUD_HYPERVISOR_COMMIT_SHA="eabdd84f6582b9e08f7865b13b24f8ea76ec646e"
+version_increment="9"
 
 git_src_commit "$CLOUD_HYPERVISOR_COMMIT_SHA" https://github.com/cyberus-technology/cloud-hypervisor.git
 


### PR DESCRIPTION
- Added security fixes for the virtio-block async I/O path, including protection against a use-after-free scenario documented as [GHSA-f47p-p25q-83rh](https://github.com/cloud-hypervisor/cloud-hypervisor/security/advisories/GHSA-f47p-p25q-83rh) / CVE-2026-45782.
- Hardened virtio-block and virtio-net against corrupted virtqueue requests by marking affected devices as NEEDS_RESET and stopping queue processing until the guest resets the device.
- Fixed a restore/live-migration edge case where stale device snapshot state could incorrectly affect later hotplug operations after restore.