### PR TITLE
Upgrade CLOUD_HYPERVISOR to tag gardenlinux-release-26-06-16 (4a117819d3d8c81cfa48d2f7cf9ba7c440ab5d30)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+cloud-hypervisor (52.0-1) stable unstable bionic focal impish jammy kinetic; urgency=low
+
+  * Cloud Hypervisor 52.0
+
+cloud-hypervisor (51.0-1) stable unstable bionic focal impish jammy kinetic; urgency=low
+
+  * Cloud Hypervisor 51.0
+
 cloud-hypervisor (50.0-1) stable unstable bionic focal impish jammy kinetic; urgency=low
 
   * Cloud Hypervisor 50.0

--- a/debian/control
+++ b/debian/control
@@ -2,6 +2,7 @@ Source: cloud-hypervisor-gl
 Maintainer: Anatol Belski <anbelski@linux.microsoft.com>
 Homepage: https://www.cloudhypervisor.org/
 Build-Depends: debhelper, debhelper-compat (= 10), rustup, gcc, binutils, libssl-dev, libcap2-bin
+Rules-Requires-Root: binary-targets
 
 
 Package: cloud-hypervisor-gl

--- a/patches/changelog.patch
+++ b/patches/changelog.patch
@@ -1,17 +1,16 @@
 diff --git a/debian/changelog b/debian/changelog
-index 221d265..8b74e0a 100644
+index 2b3cf6b..38eb559 100644
 --- a/debian/changelog
 +++ b/debian/changelog
-@@ -1,3 +1,12 @@
-+cloud-hypervisor-gl (51.1-1gl0~bp1877) testing; urgency=low
+@@ -1,3 +1,11 @@
++cloud-hypervisor-gl (52.1-1gl0~bp1877) stable unstable bionic focal impish jammy kinetic; urgency=low
 +
-+  * Cloud Hypervisor 51.1
++  * Cloud Hypervisor 52.1-1gl0~bp2150 renaming
++  * Fixed a vCPU pause deadlock
++  * Fixed ACPI S5 generation to emit a complete sleep package, improving guest compatibility, notably OpenBSD boot
++  * Tightened seccomp allowlists for event-monitor and HTTP-server paths
++  * Removed a noisy VMM log message and kept minor logging behavior aligned with the fork
 +
-+cloud-hypervisor-gl (50.0-1gl0~bp1877) testing; urgency=low
-+
-+  * Cloud Hypervisor 50.0
-+  * rename package
-+
- cloud-hypervisor (50.0-1) stable unstable bionic focal impish jammy kinetic; urgency=low
+ cloud-hypervisor (52.0-1) stable unstable bionic focal impish jammy kinetic; urgency=low
  
-   * Cloud Hypervisor 50.0
+   * Cloud Hypervisor 52.0

--- a/prepare_source
+++ b/prepare_source
@@ -2,7 +2,7 @@
 
 # commit sha from https://github.com/cyberus-technology/cloud-hypervisor/commits/gardenlinux/
 CLOUD_HYPERVISOR_COMMIT_SHA="4a117819d3d8c81cfa48d2f7cf9ba7c440ab5d30"
-version_increment="10"
+version_increment="0"
 
 git_src_commit "$CLOUD_HYPERVISOR_COMMIT_SHA" https://github.com/cyberus-technology/cloud-hypervisor.git
 
@@ -11,6 +11,6 @@ cp -r debian "$dir/src/"
 
 apply_patches
 
-version="51.1-1" # current obs base (do not change for rebuilds)
+version="52.1-1" # current obs base (do not change for rebuilds)
 version_suffix="gl${version_increment}~bp1877"
 message="Update to $version $version_suffix"

--- a/prepare_source
+++ b/prepare_source
@@ -1,8 +1,8 @@
 # vim: ft=bash
 
 # commit sha from https://github.com/cyberus-technology/cloud-hypervisor/commits/gardenlinux/
-CLOUD_HYPERVISOR_COMMIT_SHA="eabdd84f6582b9e08f7865b13b24f8ea76ec646e"
-version_increment="9"
+CLOUD_HYPERVISOR_COMMIT_SHA="4a117819d3d8c81cfa48d2f7cf9ba7c440ab5d30"
+version_increment="10"
 
 git_src_commit "$CLOUD_HYPERVISOR_COMMIT_SHA" https://github.com/cyberus-technology/cloud-hypervisor.git
 


### PR DESCRIPTION
Changelog

* Fixed a vCPU pause deadlock
* Update CHV to v52
* Fixed ACPI S5 generation to emit a complete sleep package, improving guest compatibility, notably OpenBSD boot.
* Tightened seccomp allowlists for event-monitor and HTTP-server paths
* Removed a noisy VMM log message and kept minor logging behavior aligned with the fork.
