### PR TITLE
Upgrade CLOUD_HYPERVISOR to tag gardenlinux-release-26-06-19 (079ed4dcb9bbc168405fe4462248ec3663da863a)

### DIFF
--- a/prepare_source
+++ b/prepare_source
@@ -1,8 +1,8 @@
 # vim: ft=bash
 
 # commit sha from https://github.com/cyberus-technology/cloud-hypervisor/commits/gardenlinux/
-CLOUD_HYPERVISOR_COMMIT_SHA="4a117819d3d8c81cfa48d2f7cf9ba7c440ab5d30"
-version_increment="0"
+CLOUD_HYPERVISOR_COMMIT_SHA="079ed4dcb9bbc168405fe4462248ec3663da863a"
+version_increment="1"
 
 git_src_commit "$CLOUD_HYPERVISOR_COMMIT_SHA" https://github.com/cyberus-technology/cloud-hypervisor.git
 


### PR DESCRIPTION
Changes included
* block: Retry locking when interrupted by EINTR
* vmm: prevent serial manager TCP shutdown deadlock
