### PR TITLE
Customize Renovate config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,8 @@ on:
       - main
       - rel-1877
       - sta-1877
+      - rel-2150
+      - sta-2150
   workflow_dispatch:
   # on pr
   pull_request:
@@ -11,6 +13,8 @@ on:
       - main
       - rel-1877
       - sta-1877
+      - rel-2150
+      - sta-2150
   schedule:
     - cron: '0 0 * * *'
 jobs:

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,22 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
+  "extends": ["config:best-practices"],
+  "baseBranchPatterns": [
+    "$default",
+    "/^rel-\\d+$/",
+    "/^sta-\\d+$/"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^prepare_source$/"],
+      "matchStrings": [
+        "CLOUD_HYPERVISOR_COMMIT_SHA=\"(?<currentDigest>[0-9a-f]{40})\""
+      ],
+      "currentValueTemplate": "gardenlinux",
+      "depNameTemplate": "cyberus-technology/cloud-hypervisor",
+      "packageNameTemplate": "https://github.com/cyberus-technology/cloud-hypervisor.git",
+      "datasourceTemplate": "git-refs"
+    }
   ]
 }


### PR DESCRIPTION
- Use `config:best-practices` so the workflow refs are pinned to a digest and tracked
- Add baseBranchPatterns for the `rel-*` and `sta-*` branches
- Add a regex customManager that tracks `CLOUD_HYPERVISOR_COMMIT_SHA` in `prepare_source` against `cyberus-technology/cloud-hypervisor`
- Enable CI on `rel-2150` and `sta-2150`
