### PR TITLE
update renovate and use tags

### DIFF
--- a/prepare_source
+++ b/prepare_source
@@ -1,10 +1,10 @@
 # vim: ft=bash
 
-# commit sha from https://github.com/cyberus-technology/cloud-hypervisor/commits/gardenlinux/
-CLOUD_HYPERVISOR_COMMIT_SHA="079ed4dcb9bbc168405fe4462248ec3663da863a"
+# release tag from https://github.com/cyberus-technology/cloud-hypervisor/tags
+CLOUD_HYPERVISOR_RELEASE_TAG="gardenlinux-release-26-06-19"
 version_increment="1"
 
-git_src_commit "$CLOUD_HYPERVISOR_COMMIT_SHA" https://github.com/cyberus-technology/cloud-hypervisor.git
+git_src_commit "$CLOUD_HYPERVISOR_RELEASE_TAG" https://github.com/cyberus-technology/cloud-hypervisor.git
 
 # debian specific things
 cp -r debian "$dir/src/"

--- a/renovate.json
+++ b/renovate.json
@@ -11,12 +11,34 @@
   ],
   "packageRules": [
     {
+      "description": "Track GitHub releases for main and rel-* branches",
       "matchDepNames": ["cyberus-technology/cloud-hypervisor"],
+      "matchBaseBranches": ["$default", "/^rel-\\d+$/"],
+      "sourceUrl": "https://github.com/cyberus-technology/cloud-hypervisor",
+      "allowedVersions": "/^gardenlinux-release-/"
+    },
+    {
+      "description": "Track commits from gardenlinux-staging for sta-* branches",
+      "matchDepNames": ["cyberus-technology/cloud-hypervisor"],
+      "matchBaseBranches": ["/^sta-\\d+$/"],
       "sourceUrl": "https://github.com/cyberus-technology/cloud-hypervisor"
     }
   ],
   "customManagers": [
     {
+      "description": "Match release tags for main and rel-* branches",
+      "customType": "regex",
+      "managerFilePatterns": ["/^prepare_source$/"],
+      "matchStrings": [
+        "CLOUD_HYPERVISOR_RELEASE_TAG=\"(?<currentValue>gardenlinux-release-[^\"]+)\""
+      ],
+      "depNameTemplate": "cyberus-technology/cloud-hypervisor",
+      "packageNameTemplate": "cyberus-technology/cloud-hypervisor",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^(?<version>.+)$"
+    },
+    {
+      "description": "Match commit SHAs for sta-* branches",
       "customType": "regex",
       "managerFilePatterns": ["/^prepare_source$/"],
       "matchStrings": [


### PR DESCRIPTION
- **Switch to using tags instead of commit sha in prepare_source on releases**
- **Update renovate.json to use release tags for cloud-hypervisor**
